### PR TITLE
fix: improve error handling to prevent panics

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -51,6 +51,10 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 
 			err = next(c)
 
+			if err != nil {
+				c.Error(err)
+			}
+
 			requestID := req.Header.Get(echo.HeaderXRequestID)
 			if requestID == "" {
 				requestID = res.Header().Get(echo.HeaderXRequestID)
@@ -91,9 +95,17 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 
 			switch {
 			case status >= http.StatusInternalServerError:
-				logger.LogAttrs(context.Background(), config.ServerErrorLevel, err.Error(), attributes...)
+				var errMsg string
+				if err != nil {
+					errMsg = err.Error()
+				}
+				logger.LogAttrs(context.Background(), config.ServerErrorLevel, errMsg, attributes...)
 			case status >= http.StatusBadRequest && status < http.StatusInternalServerError:
-				logger.LogAttrs(context.Background(), config.ClientErrorLevel, err.Error(), attributes...)
+				var errMsg string
+				if err != nil {
+					errMsg = err.Error()
+				}
+				logger.LogAttrs(context.Background(), config.ClientErrorLevel, errMsg, attributes...)
 			case status >= http.StatusMultipleChoices && status < http.StatusBadRequest:
 				logger.LogAttrs(context.Background(), config.DefaultLevel, "Redirection", attributes...)
 			default:


### PR DESCRIPTION
Closes #1 

In some scenarios, the status code of the response object was set to 200, but the error was non nil. The middleware was logging 200, but echo was actually responding with 500.

In other scenarios, the status code of the response was set to 500, but the error was nil. The middleware was checking the status code of the response and if it was not ok, it tried to log the error message, which resulted in a panic.

This patch should make error handling more robust.