### PR TITLE
Avoid panic when used with the recover middleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -217,11 +217,15 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 				level = config.ServerErrorLevel
 				if err != nil {
 					msg = err.Error()
+				} else {
+					msg = http.StatusText(status)
 				}
 			} else if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
 				level = config.ClientErrorLevel
 				if err != nil {
 					msg = err.Error()
+				} else {
+					msg = http.StatusText(status)
 				}
 			}
 

--- a/middleware.go
+++ b/middleware.go
@@ -215,10 +215,14 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 			msg := "Incoming request"
 			if status >= http.StatusInternalServerError {
 				level = config.ServerErrorLevel
-				msg = err.Error()
+				if err != nil {
+					msg = err.Error()
+				}
 			} else if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
 				level = config.ClientErrorLevel
-				msg = err.Error()
+				if err != nil {
+					msg = err.Error()
+				}
 			}
 
 			logger.LogAttrs(c.Request().Context(), level, msg, attributes...)


### PR DESCRIPTION
When using a custom log handler and the recover middleware,
err is (sometimes?) nil.
