### PR TITLE
remove ignoring Internal error

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,12 +1,10 @@
 package slogecho
 
 import (
-	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
-
-	"log/slog"
 
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
@@ -135,14 +133,6 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 			userAgent := req.UserAgent()
 			ip := c.RealIP()
 			referer := c.Request().Referer()
-
-			httpErr := new(echo.HTTPError)
-			if err != nil && errors.As(err, &httpErr) {
-				status = httpErr.Code
-				if msg, ok := httpErr.Message.(string); ok {
-					err = errors.New(msg)
-				}
-			}
 
 			baseAttributes := []slog.Attr{}
 


### PR DESCRIPTION
Fixes: #21 

When returning:
```go
echo.HTTPError{
    Message: "invalid base64 text",
    Internal: errors.New("illegal base64 data at input byte 5"),
    Code: 400
}
  ```
  The logging message I get with this package is:
`{"time":"2024-02-10T17:34:20.711071-06:00","level":"WARN","msg":"invalid base64 text","request":{"time":"2024-02-10T17:34:20.710876-06:00","method":"GET","host":"localhost:8080","path":"/v1/tts/en.mp3","query":"b=thisa@@ndthat&sublanguage=AU","params":{"lang":"en.mp3"},"route":"/v1/tts/:lang","ip":"::1","referer":"","length":0},"response":{"time":"2024-02-10T17:34:20.711064-06:00","latency":188750,"status":400,"length":0},"id":"eXfzigFanXdbupcuuAzuoenRsesmUmFa"}`

The `Internal` field is completely ignored. With this change instead we'd get:

`{"time":"2024-02-10T17:43:00.356414-06:00","level":"WARN","msg":"code=400, message=invalid base64 text, internal=illegal base64 data at input byte 5","request":{"time":"2024-02-10T17:43:00.356197-06:00","method":"GET","host":"localhost:8080","path":"/v1/tts/en.mp3","query":"b=thisa@@ndthat&sublanguage=AU","params":{"lang":"en.mp3"},"route":"/v1/tts/:lang","ip":"::1","referer":"","length":0},"response":{"time":"2024-02-10T17:43:00.356394-06:00","latency":197750,"status":400,"length":0},"id":"kTIgwFfHnMydhJEbjSeakVufbPpxFWRp"}`

Happy to reformat the error if we don't like the default `Error()` format. However just ignoring the `Internal` field defeats the purpose of having it and/or requires the user to add a new error log by overriding the `DefaultHTTPErrrorHandler` just so that doesn't get ignored.
