### PR TITLE
fix: response.length always zero

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -21,7 +21,7 @@ type bodyWriter struct {
 }
 
 // implements http.ResponseWriter
-func (w bodyWriter) Write(b []byte) (int, error) {
+func (w *bodyWriter) Write(b []byte) (int, error) {
 	if w.body != nil {
 		if w.body.Len()+len(b) > w.maxSize {
 			w.body.Write(b[:w.maxSize-w.body.Len()])
@@ -35,14 +35,14 @@ func (w bodyWriter) Write(b []byte) (int, error) {
 }
 
 // implements http.Flusher
-func (w bodyWriter) Flush() {
+func (w *bodyWriter) Flush() {
 	if w.ResponseWriter.(http.Flusher) != nil {
 		w.ResponseWriter.(http.Flusher).Flush()
 	}
 }
 
 // implements http.Hijacker
-func (w bodyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (w *bodyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if w.ResponseWriter.(http.Hijacker) != nil {
 		return w.ResponseWriter.(http.Hijacker).Hijack()
 	}


### PR DESCRIPTION
Fixes #27 `response.length` value is always **0**

Before:
```json
{
  "time": "2024-04-12T18:53:18.421Z",
  "level": "INFO",
  "msg": "Incoming request",
  "request": {
    "time": "2024-04-12T18:53:18.421Z",
    "method": "POST",
    "host": "localhost:5001",
    "path": "/test",
    "query": "",
    "params": {},
    "route": "/test",
    "ip": "127.0.0.1",
    "referer": "",
    "length": 0
  },
  "response": {
    "time": "2024-04-12T18:53:18.421Z",
    "latency": 81333,
    "status": 200,
    "length": 0, <=== Invalid value
    "body": "{\"name\":\"John Doe\",\"email\":\"john.doe@test.net\"}\n"
  }
}
```

After:
```json
{
  "time": "2024-04-12T18:55:58.451Z",
  "level": "INFO",
  "msg": "Incoming request",
  "request": {
    "time": "2024-04-12T18:55:58.451Z",
    "method": "POST",
    "host": "localhost:5001",
    "path": "/test",
    "query": "",
    "params": {},
    "route": "/test",
    "ip": "127.0.0.1",
    "referer": "",
    "length": 0
  },
  "response": {
    "time": "2024-04-12T18:55:58.451Z",
    "latency": 81333,
    "status": 200,
    "length": 48, <=== Correct value
    "body": "{\"name\":\"John Doe\",\"email\":\"john.doe@test.net\"}\n"
  }
}
```