### PR TITLE
fix: httpErr always non-nil

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -3,11 +3,10 @@ package slogecho
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
-
-	"log/slog"
 
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
@@ -141,7 +140,7 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 			ip := c.RealIP()
 			referer := c.Request().Referer()
 
-			httpErr := new(echo.HTTPError)
+			var httpErr *echo.HTTPError
 			if err != nil && errors.As(err, &httpErr) {
 				status = httpErr.Code
 				if msg, ok := httpErr.Message.(string); ok {


### PR DESCRIPTION
Decalre  `httpErr` using `httpErr := new(echo.HTTPError)` will cause it to be non-nil, which make following code`if httpErr != nil` always `true` and will always log a error attribute, so we should decalre  `httpErr` using `var httpErr *echo.HTTPError` .