### PR TITLE
Cast error into *echo.HTTPError

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -128,7 +128,11 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 			err = next(c)
 
 			if err != nil {
-				c.Error(err)
+				if _, ok := err.(*echo.HTTPError); !ok {
+					err = echo.
+						NewHTTPError(http.StatusInternalServerError).
+						WithInternal(err)
+				}
 			}
 
 			status := res.Status


### PR DESCRIPTION
This update will turn std `error` into `*echo.HTTPError`. Fixing #35.

```go
e.GET("/", func(c echo.Context) error {
    return errors.New("An error")
})
```

@philipjoh WDYT ?
