### PR TITLE
Preserve echo.HTTPError error types passing through middleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -144,11 +144,13 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 			ip := c.RealIP()
 			referer := c.Request().Referer()
 
+			errMsg := err
+
 			var httpErr *echo.HTTPError
 			if err != nil && errors.As(err, &httpErr) {
 				status = httpErr.Code
 				if msg, ok := httpErr.Message.(string); ok {
-					err = errors.New(msg)
+					errMsg = errors.New(msg)
 				}
 			}
 
@@ -271,14 +273,14 @@ func NewWithConfig(logger *slog.Logger, config Config) echo.MiddlewareFunc {
 			if status >= http.StatusInternalServerError {
 				level = config.ServerErrorLevel
 				if err != nil {
-					msg = err.Error()
+					msg = errMsg.Error()
 				} else {
 					msg = http.StatusText(status)
 				}
 			} else if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
 				level = config.ClientErrorLevel
 				if err != nil {
-					msg = err.Error()
+					msg = errMsg.Error()
 				} else {
 					msg = http.StatusText(status)
 				}


### PR DESCRIPTION
Without this patch all errors will be downgraded to a basic error type
when going through this middleware
